### PR TITLE
Fix regression in include file list

### DIFF
--- a/icinga2.spec
+++ b/icinga2.spec
@@ -678,7 +678,8 @@ fi
 %attr(0750,%{icinga_user},%{icinga_group}) %dir %{_localstatedir}/spool/%{name}
 %attr(0770,%{icinga_user},%{icinga_group}) %dir %{_localstatedir}/spool/%{name}/perfdata
 %attr(0750,%{icinga_user},%{icinga_group}) %dir %{_localstatedir}/spool/%{name}/tmp
-%attr(0750,%{icinga_user},%{icinga_group}) %{_datadir}/%{name}/include
+%attr(0750,%{icinga_user},%{icinga_group}) %dir %{_datadir}/%{name}/include
+%{_datadir}/%{name}/include/*
 
 %files doc
 %defattr(-,root,root,-)


### PR DESCRIPTION
The issue was introduced by the commit 900b7cf3d9bba8e8c0d3fb38405a14ffe392a919

The preceding attr was marking not only the directory but also the files
as executable.

Sorry for that.