### PR TITLE
Fix selinux dependency on Fedora

### DIFF
--- a/icinga2.spec
+++ b/icinga2.spec
@@ -260,8 +260,14 @@ BuildRequires:  checkpolicy
 BuildRequires:  hardlink
 BuildRequires:  selinux-policy-devel
 Requires:       %{name}-bin = %{version}-%{release}
+%if 0%{?fedora}
+Requires(post):   policycoreutils-python-utils
+Requires(postun): policycoreutils-python-utils
+%else
 Requires(post):   policycoreutils-python
 Requires(postun): policycoreutils-python
+%endif
+
 
 %description selinux
 SELinux policy module supporting icinga2.

--- a/icinga2.spec
+++ b/icinga2.spec
@@ -260,7 +260,7 @@ BuildRequires:  checkpolicy
 BuildRequires:  hardlink
 BuildRequires:  selinux-policy-devel
 Requires:       %{name}-bin = %{version}-%{release}
-%if 0%{?fedora}
+%if 0%{?fedora} >= 28 || 0%{?rhel} >= 8
 Requires(post):   policycoreutils-python-utils
 Requires(postun): policycoreutils-python-utils
 %else


### PR DESCRIPTION
On Fedora semanage is provided by policycoreutils-python-utils.

refs icinga/icinga2#6625